### PR TITLE
Change boost download URL

### DIFF
--- a/meta/recipes-support/boost/boost-1.75.0.inc
+++ b/meta/recipes-support/boost/boost-1.75.0.inc
@@ -11,7 +11,7 @@ BOOST_VER = "${@"_".join(d.getVar("PV").split("."))}"
 BOOST_MAJ = "${@"_".join(d.getVar("PV").split(".")[0:2])}"
 BOOST_P = "boost_${BOOST_VER}"
 
-SRC_URI = "https://dl.bintray.com/boostorg/release/${PV}/source/${BOOST_P}.tar.bz2"
+SRC_URI = "https://boostorg.jfrog.io/artifactory/main/release/${PV}/source/${BOOST_P}.tar.bz2"
 SRC_URI[sha256sum] = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
 
 UPSTREAM_CHECK_URI = "http://www.boost.org/users/download/"


### PR DESCRIPTION
Hi,

the download URL of boost has changed (see also [upstream](https://github.com/yoctoproject/poky/blob/f82ed3a207c68bab30e2fd6fee0181f85c8cd0a6/meta/recipes-support/boost/boost-1.83.0.inc)).

Could you adjust the URL, please? 